### PR TITLE
Change architecture detection method during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,10 @@ ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
     BEASTPORT=30005 \
     MLAT_SERVER=mlat1.rb24.com:40900
 
-RUN /src/buildscripts/build.sh
+RUN set -x && \
+    /src/buildscripts/build.sh && \
+    # Make sure we have an init
+    test -f /init
 
 COPY rootfs/ /
 

--- a/imagebuildscripts/build.sh
+++ b/imagebuildscripts/build.sh
@@ -2,7 +2,7 @@
 
 # Verbosity (x)
 # Exit on any error (e)
-set -xe
+set -x
 
 apt-get update
 apt-get install -y --no-install-recommends file

--- a/imagebuildscripts/build.sh
+++ b/imagebuildscripts/build.sh
@@ -65,7 +65,7 @@ fi
 
 echo "========== Attempting build for $(ARCH) =========="
 
-if [ "$ARCH" = "x86_64" ]
+if [ "$ARCH" = "amd64" ]
 then
     exec \
         /src/buildscripts/build.amd64.sh

--- a/imagebuildscripts/build.sh
+++ b/imagebuildscripts/build.sh
@@ -4,24 +4,78 @@
 # Exit on any error (e)
 set -xe
 
-echo "========== Attempting build for $(uname -m) =========="
+apt-get update
+apt-get install -y --no-install-recommends file
 
-if [ "$(uname -m)" = "x86_64" ]
+# If cross-building, we have no way to determine this without looking at the installed binaries using libmagic/file
+# Do we have libmagic/file installed
+
+# Make sure `file` (libmagic) is available
+FILEBINARY=$(which file)
+if [ $? -ne 0 ]; then
+  echo "ERROR: 'file' (libmagic) not available, cannot detect architecture!"
+  exit 1
+fi
+FILEOUTPUT=$("${FILEBINARY}" -L "${FILEBINARY}")
+
+# 32-bit x86
+# Example output:
+# /usr/bin/file: ELF 32-bit LSB shared object, Intel 80386, version 1 (SYSV), dynamically linked, interpreter /lib/ld-musl-i386.so.1, stripped
+# /usr/bin/file: ELF 32-bit LSB shared object, Intel 80386, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux.so.2, for GNU/Linux 3.2.0, BuildID[sha1]=d48e1d621e9b833b5d33ede3b4673535df181fe0, stripped  
+echo ${FILEOUTPUT} | grep "Intel 80386" > /dev/null
+if [ $? -eq 0 ]; then
+  ARCH="x86"
+fi
+
+# x86-64
+# Example output:
+# /usr/bin/file: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-musl-x86_64.so.1, stripped
+# /usr/bin/file: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 3.2.0, BuildID[sha1]=6b0b86f64e36f977d088b3e7046f70a586dd60e7, stripped
+echo ${FILEOUTPUT} | grep "x86-64" > /dev/null
+if [ $? -eq 0 ]; then
+  ARCH="amd64"
+fi
+
+# armel
+# /usr/bin/file: ELF 32-bit LSB shared object, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux.so.3, for GNU/Linux 3.2.0, BuildID[sha1]=f57b617d0d6cd9d483dcf847b03614809e5cd8a9, stripped
+echo ${FILEOUTPUT} | grep "ARM" > /dev/null
+if [ $? -eq 0 ]; then
+
+  ARCH="arm"
+
+  # armhf
+  # Example outputs:
+  # /usr/bin/file: ELF 32-bit LSB shared object, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-musl-armhf.so.1, stripped  # /usr/bin/file: ELF 32-bit LSB shared object, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-armhf.so.3, for GNU/Linux 3.2.0, BuildID[sha1]=921490a07eade98430e10735d69858e714113c56, stripped
+  # /usr/bin/file: ELF 32-bit LSB shared object, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-armhf.so.3, for GNU/Linux 3.2.0, BuildID[sha1]=921490a07eade98430e10735d69858e714113c56, stripped
+  echo ${FILEOUTPUT} | grep "armhf" > /dev/null
+  if [ $? -eq 0 ]; then
+    ARCH="armhf"
+  fi
+
+  # arm64
+  # Example output:
+  # /usr/bin/file: ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-musl-aarch64.so.1, stripped
+  # /usr/bin/file: ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, BuildID[sha1]=a8d6092fd49d8ec9e367ac9d451b3f55c7ae7a78, stripped
+  echo ${FILEOUTPUT} | grep "aarch64" > /dev/null
+  if [ $? -eq 0 ]; then
+    ARCH="aarch64"
+  fi
+
+fi
+
+echo "========== Attempting build for $(ARCH) =========="
+
+if [ "$ARCH" = "x86_64" ]
 then
     exec \
         /src/buildscripts/build.amd64.sh
 
-elif [ "$(uname -m)" = "armv7l" ]
+elif [ "$ARCH" = "armhf" ]
 then
     exec \
         /src/buildscripts/build.arm32.sh
 
-elif [ "$(uname -m)" = "armhf" ]
-then
-    exec \
-        /src/buildscripts/build.arm32.sh
-
-elif [ "$(uname -m)" = "aarch64" ]
+elif [ "$ARCH" = "aarch64" ]
 then
     exec \
         /src/buildscripts/build.arm64.sh


### PR DESCRIPTION
Abandon `uname -m` to detect architecture, and instead use `file` to check binary type.