### PR TITLE
Fix issue 25 (#27)

### DIFF
--- a/rootfs/etc/cont-init.d/01-rbfeeder
+++ b/rootfs/etc/cont-init.d/01-rbfeeder
@@ -60,13 +60,19 @@ fi
 
   echo "external_port=$BEASTPORT"
 
-  # Attempt to resolve BEASTHOST into an IP address
-  BEASTIP=$(s6-dnsip4 "$BEASTHOST")
-  echo "external_host=$BEASTIP"
+} >> /etc/rbfeeder.ini
+
+# Attempt to resolve BEASTHOST into an IP address
+if BEASTIP=$(s6-dnsip4 "$BEASTHOST" 2> /dev/null); then
+  echo "external_host=$BEASTIP" >> /etc/rbfeeder.ini
+else
+  echo "external_host=$BEASTHOST" >> /etc/rbfeeder.ini
+fi
+
+{
   echo "[mlat]"
   echo "mlat_cmd=/usr/bin/mlat-client"
   echo "autostart_mlat=false"
-
 } >> /etc/rbfeeder.ini
 
 # Create log dirs

--- a/rootfs/etc/services.d/mlat-client/run
+++ b/rootfs/etc/services.d/mlat-client/run
@@ -1,73 +1,71 @@
-#!/usr/bin/with-contenv sh
-#shellcheck shell=sh
+#!/usr/bin/with-contenv bash
+#shellcheck shell=bash
 
 # try to get station serial number
 SN=$(grep -E "^sn=.*$" /etc/rbfeeder.ini)
+MLAT_USER=$(echo "$SN" | cut -d "=" -f 2 | tr -d " ")
 
-if grep -E "^sn=.*$" /etc/rbfeeder.ini; then
-    echo "[mlat-client] Delaying mlat-client startup until rbfeeder receives station sn..."
-    sleep 30
-    
-else
-    
-    MLAT_USER=$(echo "$SN" | cut -d "=" -f 2)
+if [[ -z "$MLAT_USER" ]]; then
+  echo "[mlat-client] Delaying mlat-client startup until rbfeeder receives station sn..."
+  sleep 30
+  exit 1
+fi
 
-    if [ "$(uname -m)" = "x86_64" ]
+if [ "$(uname -m)" = "x86_64" ]
     then
         
-        exec /usr/bin/qemu-arm-static /usr/bin/python3 /usr/bin/mlat-client \
-            --input-type "${MLAT_INPUT_TYPE}" \
-            --input-connect "${BEASTHOST}:${BEASTPORT}" \
-            --results beast,listen,30105 \
-            --lat "${LAT}" \
-            --lon "${LONG}" \
-            --alt "${ALT}m" \
-            --user "${MLAT_USER}" \
-            --server "${MLAT_SERVER}" \
-            2>&1 | awk -W Interactive '{print "[mlat-client] " $0}'
+    exec /usr/bin/qemu-arm-static /usr/bin/python3 /usr/bin/mlat-client \
+        --input-type "${MLAT_INPUT_TYPE}" \
+        --input-connect "${BEASTHOST}:${BEASTPORT}" \
+        --results beast,listen,30105 \
+        --lat "${LAT}" \
+        --lon "${LONG}" \
+        --alt "${ALT}m" \
+        --user "${MLAT_USER}" \
+        --server "${MLAT_SERVER}" \
+        2>&1 | awk -W Interactive '{print "[mlat-client] " $0}'
 
-    elif [ "$(uname -m)" = "armv7l" ]
-    then
-        exec /usr/bin/mlat-client \
-            --input-type "${MLAT_INPUT_TYPE}" \
-            --input-connect "${BEASTHOST}:${BEASTPORT}" \
-            --results beast,listen,30105 \
-            --lat "${LAT}" \
-            --lon "${LONG}" \
-            --alt "${ALT}m" \
-            --user "${MLAT_USER}" \
-            --server "${MLAT_SERVER}" \
-            2>&1 | awk -W Interactive '{print "[mlat-client] " $0}'
+elif [ "$(uname -m)" = "armv7l" ]
+then
+    exec /usr/bin/mlat-client \
+        --input-type "${MLAT_INPUT_TYPE}" \
+        --input-connect "${BEASTHOST}:${BEASTPORT}" \
+        --results beast,listen,30105 \
+        --lat "${LAT}" \
+        --lon "${LONG}" \
+        --alt "${ALT}m" \
+        --user "${MLAT_USER}" \
+        --server "${MLAT_SERVER}" \
+        2>&1 | awk -W Interactive '{print "[mlat-client] " $0}'
 
-    elif [ "$(uname -m)" = "armhf" ]
-    then
-        exec /usr/bin/mlat-client \
-            --input-type "${MLAT_INPUT_TYPE}" \
-            --input-connect "${BEASTHOST}:${BEASTPORT}" \
-            --results beast,listen,30105 \
-            --lat "${LAT}" \
-            --lon "${LONG}" \
-            --alt "${ALT}m" \
-            --user "${MLAT_USER}" \
-            --server "${MLAT_SERVER}" \
-            2>&1 | awk -W Interactive '{print "[mlat-client] " $0}'
+elif [ "$(uname -m)" = "armhf" ]
+then
+    exec /usr/bin/mlat-client \
+        --input-type "${MLAT_INPUT_TYPE}" \
+        --input-connect "${BEASTHOST}:${BEASTPORT}" \
+        --results beast,listen,30105 \
+        --lat "${LAT}" \
+        --lon "${LONG}" \
+        --alt "${ALT}m" \
+        --user "${MLAT_USER}" \
+        --server "${MLAT_SERVER}" \
+        2>&1 | awk -W Interactive '{print "[mlat-client] " $0}'
 
-    elif [ "$(uname -m)" = "aarch64" ]
-    then
-        exec /usr/bin/mlat-client \
-            --input-type "${MLAT_INPUT_TYPE}" \
-            --input-connect "${BEASTHOST}:${BEASTPORT}" \
-            --results beast,listen,30105 \
-            --lat "${LAT}" \
-            --lon "${LONG}" \
-            --alt "${ALT}m" \
-            --user "${MLAT_USER}" \
-            --server "${MLAT_SERVER}" \
-            2>&1 | awk -W Interactive '{print "[mlat-client] " $0}'
+elif [ "$(uname -m)" = "aarch64" ]
+then
+    exec /usr/bin/mlat-client \
+        --input-type "${MLAT_INPUT_TYPE}" \
+        --input-connect "${BEASTHOST}:${BEASTPORT}" \
+        --results beast,listen,30105 \
+        --lat "${LAT}" \
+        --lon "${LONG}" \
+        --alt "${ALT}m" \
+        --user "${MLAT_USER}" \
+        --server "${MLAT_SERVER}" \
+        2>&1 | awk -W Interactive '{print "[mlat-client] " $0}'
 
-    else
-        sleep 60
-        exit 1
-    fi
-
+else
+    sleep 60
+    exit 1
 fi
+


### PR DESCRIPTION
* Fix for issue #25

If an IP is given for BEASTHOST, s6-dnsip4 would throw an error. This captures that error and passes BEASTHOST through to rbfeeder.

* Suppress s6-dnsip4 error message
* Add sanity checks for mlat-client run script
* Updates to mlat-client run script