### PR TITLE
Replace MIT keyserver with Ubuntu's

### DIFF
--- a/rootfs/buildscripts/build.amd64.sh
+++ b/rootfs/buildscripts/build.amd64.sh
@@ -30,7 +30,7 @@ wget -q -O - https://raw.githubusercontent.com/mikenye/deploy-s6-overlay/master/
 
 echo "========== Import apt keys =========="
 # AirNavSystems (for rbfeeder)
-apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 1D043681
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 1D043681
 
 echo "========== Add apt repos =========="
 echo "deb https://apt.rb24.com/ $VERS main" > /etc/apt/sources.list.d/rb24.list

--- a/rootfs/buildscripts/build.arm32.sh
+++ b/rootfs/buildscripts/build.arm32.sh
@@ -27,7 +27,7 @@ wget -q -O - https://raw.githubusercontent.com/mikenye/deploy-s6-overlay/master/
 
 echo "========== Import apt keys =========="
 # AirNavSystems (for rbfeeder)
-apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 1D043681
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 1D043681
 
 echo "========== Add apt repos =========="
 echo "deb https://apt.rb24.com/ $VERS main" > /etc/apt/sources.list.d/rb24.list

--- a/rootfs/buildscripts/build.arm64.sh
+++ b/rootfs/buildscripts/build.arm64.sh
@@ -27,7 +27,7 @@ wget -q -O - https://raw.githubusercontent.com/mikenye/deploy-s6-overlay/master/
 
 echo "========== Import apt keys =========="
 # AirNavSystems (for rbfeeder)
-apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 1D043681
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 1D043681
 
 echo "========== Add apt repos =========="
 echo "deb https://apt.rb24.com/ $VERS main" > /etc/apt/sources.list.d/rb24.list

--- a/rootfs/buildscripts/build.i386.sh
+++ b/rootfs/buildscripts/build.i386.sh
@@ -30,7 +30,7 @@ wget -q -O - https://raw.githubusercontent.com/mikenye/deploy-s6-overlay/master/
 
 echo "========== Import apt keys =========="
 # AirNavSystems (for rbfeeder)
-apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 1D043681
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 1D043681
 
 echo "========== Add apt repos =========="
 echo "deb https://apt.rb24.com/ $VERS main" > /etc/apt/sources.list.d/rb24.list


### PR DESCRIPTION
As reported in #46 it appears the MIT server is unpredictable, so switch to using the one provided by Ubuntu.